### PR TITLE
Added "Aha!" support

### DIFF
--- a/data.json
+++ b/data.json
@@ -1,6 +1,10 @@
 {
   "services": [
     {
+      "name": "Aha!",
+      "url": "http://support.aha.io/entries/36821618-Two-factor-authentication-2FA-user-set-up"
+    },
+    {
       "name": "Amazon Web Services",
       "url": "http://aws.amazon.com/mfa/virtual_mfa_applications/?tag=gmgamzn-20"
     },


### PR DESCRIPTION
Closes issue #17

Aha!'s [blog post](http://blog.aha.io/index.php/we-added-duo-security-two-factor-authentication-because-it-was-the-right-thing-to-do/) and [support page](http://support.aha.io/entries/36821618-Two-factor-authentication-2FA-user-set-up).
