### PR TITLE
Remove Xenforo

### DIFF
--- a/data.json
+++ b/data.json
@@ -430,6 +430,10 @@
       "howto": "http://en.support.wordpress.com/security/two-step-authentication/"
     },
     {
+      "name": "Xenforo",
+      "url": "https://xenforo.com/community/threads/two-step-verification-and-security-improvements.99881/"
+    },
+    {
       "name": "Yahoo",
       "url": "https://edit.yahoo.com/commchannel/sec_chal_manage"
     },

--- a/data.json
+++ b/data.json
@@ -430,10 +430,6 @@
       "howto": "http://en.support.wordpress.com/security/two-step-authentication/"
     },
     {
-      "name": "XenForo",
-      "url": "http://xenforo.com/community/resources/freddyshouse-two-factor-authentication.1663/"
-    },
-    {
       "name": "Yahoo",
       "url": "https://edit.yahoo.com/commchannel/sec_chal_manage"
     },

--- a/data.json
+++ b/data.json
@@ -431,7 +431,7 @@
     },
     {
       "name": "Xenforo",
-      "url": "https://xenforo.com/community/threads/two-step-verification-and-security-improvements.99881/"
+      "howto": "https://xenforo.com/community/threads/two-step-verification-and-security-improvements.99881/"
     },
     {
       "name": "Yahoo",


### PR DESCRIPTION
The plugin mentioned is dead. Moreover Xenforo has included [Two factor authentication as a core feature](https://xenforo.com/community/threads/two-step-verification-and-security-improvements.99881/). I don't think it makes sense in mentioning it here any more.